### PR TITLE
Uppercase XML Elements

### DIFF
--- a/lib/intacct/xml_request.rb
+++ b/lib/intacct/xml_request.rb
@@ -52,6 +52,10 @@ module Intacct
         }
       end
 
+      builder.doc.root.children.last.children.last.child.child.child.traverse do |node|
+        node.name = node.name.upcase if node.kind_of?(Nokogiri::XML::Element)
+      end
+
       xml = builder.doc.root.to_xml
 
       uri = URI(URL)
@@ -59,6 +63,5 @@ module Intacct
       res = Net::HTTP.post_form(uri, 'xmlrequest' => xml)
       Nokogiri::XML(res.body)
     end
-
   end
 end


### PR DESCRIPTION
We've had some problems with our code breaking do to certain elements requiring uppercase. All Intacct Api example are in this format so, let's make sure all elements are made uppercase.

This needs QA.