### PR TITLE
Add `itemid` field to expenses

### DIFF
--- a/lib/intacct/models/expense.rb
+++ b/lib/intacct/models/expense.rb
@@ -43,6 +43,7 @@ module Intacct
               xml.departmentid expense[:departmentid]
               xml.projectid    expense[:projectid]
               xml.billable     expense[:billable]
+              xml.itemid       expense[:itemid]
             }
           }
         }


### PR DESCRIPTION
Intacct expenses require `itemid` to be passed if we want to set the billable flag.