### PR TITLE
Update order of attributes so `itemid` is passed

### DIFF
--- a/lib/intacct/models/expense.rb
+++ b/lib/intacct/models/expense.rb
@@ -42,8 +42,8 @@ module Intacct
               xml.locationid   expense[:locationid]
               xml.departmentid expense[:departmentid]
               xml.projectid    expense[:projectid]
-              xml.billable     expense[:billable]
               xml.itemid       expense[:itemid]
+              xml.billable     expense[:billable]
             }
           }
         }


### PR DESCRIPTION
Because Intacct is awesome, the payload attributes must be in the correct order.