### PR TITLE
Add projectkey as a creatable attribute for observed_percent_completed

### DIFF
--- a/lib/intacct/models/observed_percent_completed.rb
+++ b/lib/intacct/models/observed_percent_completed.rb
@@ -5,11 +5,12 @@ module Intacct
       api_name "OBSPCTCOMPLETED"
 
       def create_xml(xml)
-        xml.type      attributes.type
-        xml.taskkey   attributes.taskkey
-        xml.ASOFDATE  attributes.asofdate
-        xml.percent   attributes.percent
-        xml.note      attributes.note
+        xml.type       attributes.type
+        xml.taskkey    attributes.taskkey
+        xml.projectkey attributes.projectkey
+        xml.ASOFDATE   attributes.asofdate
+        xml.percent    attributes.percent
+        xml.note       attributes.note
       end
 
       def update_xml(xml)


### PR DESCRIPTION
Add projectkey as a creatable attribute for the observed_percent_completed endpoint.

This is necessary for creating an observed_percent_completed for a project, because we use projectkey instead of taskkey