### PR TITLE
More Robust Date Format handling

### DIFF
--- a/bin/sync_schema
+++ b/bin/sync_schema
@@ -124,7 +124,7 @@ class XmlType
     when :custom_fields
       custom_field_ruby(action)
     when :date
-      append_presence_check("xml.#{xml_name} attributes.#{name}.strftime(\"%m/%d/%Y\")", required)
+      append_presence_check("xml.#{xml_name} format_date(attributes.#{name})", required)
     when :ref
       ref.to_ruby(action, required: required)
     when :array

--- a/lib/intacct/base.rb
+++ b/lib/intacct/base.rb
@@ -2,6 +2,8 @@ module Intacct
   Base = Struct.new(:client, :attributes) do
     include Intacct::Actions
 
+    DATE_FORMAT = "%m/%d/%Y".freeze
+
     attr_accessor :client, :sent_xml, :intacct_action, :api_name, :errors
 
     delegate :formatted_error_message, to: :class
@@ -52,6 +54,20 @@ module Intacct
 
     def persisted?
       !!attributes["recordno"]
+    end
+
+    protected
+
+    def format_date(date_object)
+      return if date_object.blank?
+
+      if date_object.is_a?(Date) || date_object.is_a?(Time)
+        date_object.strftime(DATE_FORMAT)
+      elsif date_object.is_a?(String)
+        Date.strptime(date_object, DATE_FORMAT).strftime(DATE_FORMAT)
+      else
+        date_object
+      end
     end
 
     private

--- a/lib/intacct/models/project.rb
+++ b/lib/intacct/models/project.rb
@@ -64,8 +64,8 @@ module Intacct
         xml.MANAGERID attributes.managerid if attributes.managerid.present?
         xml.CUSTUSERID attributes.custuserid if attributes.custuserid.present?
         xml.SALESCONTACTID attributes.salescontactid if attributes.salescontactid.present?
-        xml.BEGINDATE attributes.begindate.strftime("%m/%d/%Y") if attributes.begindate.present?
-        xml.ENDDATE attributes.enddate.strftime("%m/%d/%Y") if attributes.enddate.present?
+        xml.BEGINDATE format_date(attributes.begindate) if attributes.begindate.present?
+        xml.ENDDATE format_date(attributes.enddate) if attributes.enddate.present?
         xml.DEPARTMENTID attributes.departmentid if attributes.departmentid.present?
         xml.LOCATIONID attributes.locationid if attributes.locationid.present?
         xml.CLASSID attributes.classid if attributes.classid.present?
@@ -105,7 +105,7 @@ module Intacct
                     xml.EMPLOYEEID attributes.employeeid
                     xml.ITEMID attributes.itemid if attributes.itemid.present?
                     xml.RESOURCEDESCRIPTION attributes.resourcedescription if attributes.resourcedescription.present?
-                    xml.STARTDATE attributes.startdate.strftime("%m/%d/%Y") if attributes.startdate.present?
+                    xml.STARTDATE format_date(attributes.startdate) if attributes.startdate.present?
                     xml.BILLINGRATE attributes.billingrate if attributes.billingrate.present?
                     xml.EXPENSERATE attributes.expenserate if attributes.expenserate.present?
                     xml.POAPRATE attributes.poaprate if attributes.poaprate.present?

--- a/lib/intacct/models/task.rb
+++ b/lib/intacct/models/task.rb
@@ -54,8 +54,8 @@ module Intacct
         xml.TASKNAME attributes.taskname
         xml.PROJECTID attributes.projectid
         xml.TASKID attributes.taskid if attributes.taskid.present?
-        xml.PBEGINDATE attributes.pbegindate.strftime("%m/%d/%Y") if attributes.pbegindate.present?
-        xml.PENDDATE attributes.penddate.strftime("%m/%d/%Y") if attributes.penddate.present?
+        xml.PBEGINDATE format_date(attributes.pbegindate) if attributes.pbegindate.present?
+        xml.PENDDATE format_date(attributes.penddate) if attributes.penddate.present?
         xml.ITEMID attributes.itemid if attributes.itemid.present?
         xml.BILLABLE attributes.billable if attributes.billable.present?
         xml.TASKDESCRIPTION attributes.taskdescription if attributes.taskdescription.present?
@@ -107,8 +107,8 @@ module Intacct
       def update_xml(xml)
         xml.TASKNAME attributes.taskname if attributes.taskname.present?
         xml.PROJECTID attributes.projectid if attributes.projectid.present?
-        xml.PBEGINDATE attributes.pbegindate.strftime("%m/%d/%Y") if attributes.pbegindate.present?
-        xml.PENDDATE attributes.penddate.strftime("%m/%d/%Y") if attributes.penddate.present?
+        xml.PBEGINDATE format_date(attributes.pbegindate) if attributes.pbegindate.present?
+        xml.PENDDATE format_date(attributes.penddate) if attributes.penddate.present?
         xml.ITEMID attributes.itemid if attributes.itemid.present?
         xml.BILLABLE attributes.billable if attributes.billable.present?
         xml.TASKDESCRIPTION attributes.taskdescription if attributes.taskdescription.present?


### PR DESCRIPTION
Previously we assumed all date inputs would support `strftime`. This adds a new protected method to the base model class for formatting the date.

* `Date`/`Time` objects are immediately called with `strftime`
* `Strings` are `strptime` to a `Date` object then `strftime`
* Anything else is passed through