### PR TITLE
Allow Intacct Task Start/End Dates to be Nil

### DIFF
--- a/lib/intacct/models/task.rb
+++ b/lib/intacct/models/task.rb
@@ -111,8 +111,8 @@ module Intacct
       def update_xml(xml)
         xml.TASKNAME attributes.taskname if attributes.taskname.present?
         xml.PROJECTID attributes.projectid if attributes.projectid.present?
-        xml.PBEGINDATE format_date(attributes.pbegindate) if attributes.pbegindate.present?
-        xml.PENDDATE format_date(attributes.penddate) if attributes.penddate.present?
+        xml.PBEGINDATE format_date(attributes.pbegindate)
+        xml.PENDDATE format_date(attributes.penddate)
         xml.ITEMID attributes.itemid if attributes.itemid.present?
         xml.BILLABLE attributes.billable if attributes.billable.present?
         xml.TASKDESCRIPTION attributes.taskdescription if attributes.taskdescription.present?


### PR DESCRIPTION
This change will allow us to override existing Task start/end dates and set them as nothing.

This PR is necessary to fix the bug referenced in this PR: [00026105 | Paradigm - Intacct: -1 in GL Task ID](https://www.pivotaltracker.com/story/show/174180867)
because currently we are unable to update an Intacct Task that only has a start date unless we provide both a start and end date. This change will allow us to also update a task with only a start and end date by providing neither