### PR TITLE
Add `raw_response` to objects

### DIFF
--- a/lib/intacct/actions/base.rb
+++ b/lib/intacct/actions/base.rb
@@ -16,8 +16,7 @@ module Intacct
       end
 
       def build_response
-        Intacct::Response.new(client, success: success?, body: response_body,
-                                      errors: response_errors)
+        Intacct::Response.new(client, success: success?, body: response_body, errors: response_errors, raw_response: @response)
       end
 
       def request(_options)

--- a/lib/intacct/actions/create.rb
+++ b/lib/intacct/actions/create.rb
@@ -41,6 +41,7 @@ module Intacct
           response = Intacct::Actions::Create.new(client, self, "create", options).perform
 
           @errors = response.errors
+          @raw_response = response.raw_response
 
           if response.success?
             attributes.recordno = response.body["recordno"] unless response.body.nil?

--- a/lib/intacct/base.rb
+++ b/lib/intacct/base.rb
@@ -4,7 +4,7 @@ module Intacct
 
     DATE_FORMAT = "%m/%d/%Y".freeze
 
-    attr_accessor :client, :sent_xml, :intacct_action, :api_name, :errors
+    attr_accessor :client, :sent_xml, :intacct_action, :api_name, :errors, :raw_response
 
     delegate :formatted_error_message, to: :class
 

--- a/lib/intacct/response.rb
+++ b/lib/intacct/response.rb
@@ -3,12 +3,14 @@ module Intacct
     include Intacct::Callbacks
 
     attr_accessor :client, :body, :errors
+    attr_reader :raw_response
 
     def initialize(client, options)
-      @client  = client
+      @client = client
       @success = options[:success]
-      @body    = options[:body]
-      @errors  = options[:errors] || []
+      @body = options[:body]
+      @errors = options[:errors] || []
+      @raw_response = options[:raw_response]
     end
 
     def success?

--- a/spec/lib/actions/create_spec.rb
+++ b/spec/lib/actions/create_spec.rb
@@ -1,0 +1,52 @@
+require "spec_helper"
+
+describe Intacct::Actions::Create do
+  class TestModel < Intacct::Base
+    include Intacct::Actions::Create::Helper
+  end
+
+  describe "create" do
+    subject { TestModel.new(client_double, {}) }
+    let(:options) { {} }
+    let(:create_double) { instance_double(described_class) }
+    let(:client_double) { instance_double(Intacct::Client) }
+    let(:response_double) do
+      instance_double(
+        Intacct::Response,
+        errors: ["error"],
+        body: { "recordno" => "12345" },
+        raw_response: { "raw" => "response" }
+      )
+    end
+
+    before do
+      allow(described_class).to receive(:new).with(client_double, subject, "create", options) { create_double }
+      allow(create_double).to receive(:perform) { response_double }
+    end
+
+    context "when successful" do
+      before do
+        allow(response_double).to receive(:success?) { true }
+      end
+
+      it "performs the action and adds response data to the model instance" do
+        expect(subject.create).to be_truthy
+        expect(subject.errors).to eq response_double.errors
+        expect(subject.raw_response).to eq response_double.raw_response
+        expect(subject.recordno).to eq response_double.body["recordno"]
+      end
+    end
+
+    context "when unsuccessful" do
+      before do
+        allow(response_double).to receive(:success?) { false }
+      end
+
+      it "performs the action and adds errors to the model instance" do
+        expect(subject.create).to be_falsey
+        expect(subject.errors).to eq response_double.errors
+        expect(subject.raw_response).to eq response_double.raw_response
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds a new instance variable on the model base class to contain a raw response. This can be useful with things like getting data that is outside of the typical response body like the `key` attribute on legacy create calls.