### PR TITLE
Set nokogiri version to 1.10.10

### DIFF
--- a/intacct.gemspec
+++ b/intacct.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "hooks"
-  spec.add_dependency "nokogiri"
+  spec.add_dependency "nokogiri", "~> 1.10.10"
 
   spec.add_runtime_dependency "activesupport"
 


### PR DESCRIPTION
Set nokogiri version to 1.10.10 to fix issues when updating the gem from konekti