### PR TITLE
Intacct Error Messaging on Filtering (Read By Query) Call

### DIFF
--- a/lib/intacct/base.rb
+++ b/lib/intacct/base.rb
@@ -173,7 +173,7 @@ module Intacct
         if error["description"].present? && error["description2"].present?
           "#{error["description"]}: #{error["description2"]}"
         else
-          error["description"].presence || error["description2"] || "Undefined error"
+          error["description"].presence || error["description2"].presence || "Undefined error"
         end
       end.join(" ")
     end

--- a/lib/intacct/base.rb
+++ b/lib/intacct/base.rb
@@ -170,8 +170,12 @@ module Intacct
 
     def self.formatted_error_message(errors)
       [errors].flatten.map do |error|
-        error["description"].presence || error["description2"] || "Undefined error"
-      end .join(" ")
+        if error["description"].present? && error["description2"].present?
+          "#{error["description"]}: #{error["description2"]}"
+        else
+          error["description"].presence || error["description2"] || "Undefined error"
+        end
+      end.join(" ")
     end
   end
 end

--- a/spec/lib/intacct/base_spec.rb
+++ b/spec/lib/intacct/base_spec.rb
@@ -19,4 +19,34 @@ describe Intacct::Base do
     expect(example.client).to eq(client)
     expect(example.id).to eq "12345"
   end
+
+  context "when errors are present" do
+    let(:errors) { [{ "description" => "first desc", "description2" => "second desc" }] }
+
+    it "formats the error correctly" do
+      example = Intacct::Models::Example.formatted_error_message(errors)
+
+      expect(example).to eq("first desc: second desc")
+    end
+
+    context "when description or desciption2 is not present" do
+      let(:errors) { [{ "description2" => "second desc" }] }
+
+      it "formats the error correctly" do
+        example = Intacct::Models::Example.formatted_error_message(errors)
+
+        expect(example).to eq("second desc")
+      end
+    end
+
+    context "when description and desciption2 is not present" do
+      let(:errors) { [{}] }
+
+      it "formats the error correctly" do
+        example = Intacct::Models::Example.formatted_error_message(errors)
+
+        expect(example).to eq("Undefined error")
+      end
+    end
+  end
 end

--- a/spec/lib/intacct/base_spec.rb
+++ b/spec/lib/intacct/base_spec.rb
@@ -29,7 +29,7 @@ describe Intacct::Base do
       expect(example).to eq("first desc: second desc")
     end
 
-    context "when description or desciption2 is not present" do
+    context "when only description2 is present" do
       let(:errors) { [{ "description2" => "second desc" }] }
 
       it "formats the error correctly" do


### PR DESCRIPTION
If both descriptions are present, add both to the error message.

Otherwise, same error messaging as before

