### PR TITLE
[IE-515] Update to Ruby 3 Compatibility

### DIFF
--- a/.github/workflows/rspec.yaml
+++ b/.github/workflows/rspec.yaml
@@ -1,0 +1,34 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  rspec:
+    runs-on: ubuntu-latest
+    environment: test
+    container:
+      image: ruby:3.0.6
+
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Gem cache
+        id: cache-bundle
+        uses: actions/cache@v1
+        with:
+          path: vendor/bundle
+          key: bundle-${{ hashFiles('**/Gemfile.lock') }}
+
+      - name: Bundle install
+        env:
+          RAILS_ENV: test
+        run: |
+          gem install bundler
+          bundle install
+
+      - name: Run tests
+        env:
+          RAILS_ENV: test
+        run: |
+          echo "${{ secrets.RSAKEY }}" > rsakey.pem
+          bundle exec rspec

--- a/.github/workflows/rspec.yaml
+++ b/.github/workflows/rspec.yaml
@@ -23,8 +23,8 @@ jobs:
         env:
           RAILS_ENV: test
         run: |
-          gem install bundler
-          bundle install
+          gem install bundler:2.4.14
+          bundle _2.4.14_ install
 
       - name: Run tests
         env:

--- a/.github/workflows/rspec.yaml
+++ b/.github/workflows/rspec.yaml
@@ -30,5 +30,4 @@ jobs:
         env:
           RAILS_ENV: test
         run: |
-          echo "${{ secrets.RSAKEY }}" > rsakey.pem
           bundle exec rspec

--- a/intacct.gemspec
+++ b/intacct.gemspec
@@ -19,14 +19,15 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "activesupport"
 
+  spec.add_development_dependency "cucumber"
   spec.add_development_dependency "awesome_print"
-  spec.add_development_dependency "bundler", "~> 1.3"
+  spec.add_development_dependency "bundler", "~> 2.4.14"
   spec.add_development_dependency "dotenv-rails"
   spec.add_development_dependency "faker", ">=1.2.0"
   spec.add_development_dependency "pry"
   spec.add_development_dependency "pry-byebug"
   spec.add_development_dependency "rake"
-  spec.add_development_dependency "rspec"
+  spec.add_development_dependency "rspec", "~> 2.0"
   spec.add_development_dependency "rubocop"
   spec.add_development_dependency "turnip"
 end

--- a/lib/intacct/actions/create.rb
+++ b/lib/intacct/actions/create.rb
@@ -36,7 +36,7 @@ module Intacct
 
       module Helper
         def create(options = {})
-          response = Intacct::Actions::Create.new(client, self, "create", **options).perform
+          response = Intacct::Actions::Create.new(client, self, "create", options).perform
 
           @errors = response.errors
           @raw_response = response.raw_response

--- a/lib/intacct/actions/create.rb
+++ b/lib/intacct/actions/create.rb
@@ -36,7 +36,7 @@ module Intacct
 
       module Helper
         def create(options = {})
-          response = Intacct::Actions::Create.new(client, self, "create", options).perform
+          response = Intacct::Actions::Create.new(client, self, "create", **options).perform
 
           @errors = response.errors
           @raw_response = response.raw_response

--- a/lib/intacct/base_factory.rb
+++ b/lib/intacct/base_factory.rb
@@ -13,8 +13,8 @@ module Intacct
 
     def self.delegate_to_target_class(*method_names)
       method_names.each do |method_name|
-        define_method method_name do |*args|
-          target_class.send(method_name, @client, *args)
+        define_method method_name do |*args, **kwargs|
+          target_class.send(method_name, @client, *args, **kwargs)
         end
       end
     end

--- a/spec/lib/actions/create_spec.rb
+++ b/spec/lib/actions/create_spec.rb
@@ -22,8 +22,11 @@ describe Intacct::Actions::Create do
     end
 
     before do
-      allow(described_class).to receive(:new).with(client_double, subject, "create", options) { create_double }
-      allow(create_double).to receive(:perform) { response_double }
+      allow(described_class).to receive(:new) do |*args, **kwargs|
+        expect(args).to eq [client_double, subject, "create"]
+        expect(kwargs).to eq(options)
+      end.and_return(create_double)
+      allow(create_double).to receive(:perform).and_return(response_double)
     end
 
     context "when successful" do

--- a/spec/lib/actions/create_spec.rb
+++ b/spec/lib/actions/create_spec.rb
@@ -22,9 +22,8 @@ describe Intacct::Actions::Create do
     end
 
     before do
-      allow(described_class).to receive(:new) do |*args, **kwargs|
-        expect(args).to eq [client_double, subject, "create"]
-        expect(kwargs).to eq(options)
+      allow(described_class).to receive(:new) do |*args|
+        expect(args).to eq [client_double, subject, "create", options]
       end.and_return(create_double)
       allow(create_double).to receive(:perform).and_return(response_double)
     end

--- a/spec/lib/actions/create_spec.rb
+++ b/spec/lib/actions/create_spec.rb
@@ -1,6 +1,8 @@
 require "spec_helper"
 
 describe Intacct::Actions::Create do
+  include RSpec::Mocks::ExampleMethods
+
   class TestModel < Intacct::Base
     include Intacct::Actions::Create::Helper
   end
@@ -8,10 +10,10 @@ describe Intacct::Actions::Create do
   describe "create" do
     subject { TestModel.new(client_double, {}) }
     let(:options) { {} }
-    let(:create_double) { instance_double(described_class) }
-    let(:client_double) { instance_double(Intacct::Client) }
+    let(:create_double) { double(described_class) }
+    let(:client_double) { double(Intacct::Client) }
     let(:response_double) do
-      instance_double(
+      double(
         Intacct::Response,
         errors: ["error"],
         body: { "recordno" => "12345" },

--- a/spec/lib/intacct/base_factory_spec.rb
+++ b/spec/lib/intacct/base_factory_spec.rb
@@ -4,6 +4,11 @@ describe Intacct::BaseFactory do
   module Intacct
     module Models
       class Foo
+        def self.get(*args); end
+
+        def self.read_by_query(*args); end
+
+        def self.build(*args); end
       end
     end
   end

--- a/spec/lib/intacct/base_factory_spec.rb
+++ b/spec/lib/intacct/base_factory_spec.rb
@@ -12,13 +12,18 @@ describe Intacct::BaseFactory do
   let(:klass)  { "Foo" }
   subject      { Intacct::BaseFactory.new(client, klass) }
 
+  before(:each) do
+    allow(Intacct::Models::Foo).to receive(:get)
+    allow(Intacct::Models::Foo).to receive(:read_by_query)
+    allow(Intacct::Models::Foo).to receive(:build)
+  end
+
   it "initializes correctly" do
     expect(subject.client).to       eq(client)
     expect(subject.target_class).to eq(Intacct::Models::Foo)
   end
 
   it "proxies get to the target class" do
-    allow(Intacct::Models::Foo).to receive(:get)
     subject.get("1")
     expect(Intacct::Models::Foo).to have_received(:get) do |*args, **_kwargs|
       expect(args).to eq([client, "1"])
@@ -26,7 +31,6 @@ describe Intacct::BaseFactory do
   end
 
   it "proxies read_by_query to the target class" do
-    allow(Intacct::Models::Foo).to receive(:read_by_query)
     subject.read_by_query(query: "FOO")
     expect(Intacct::Models::Foo).to have_received(:read_by_query) do |*args, **kwargs|
       expect(args).to eq([client])
@@ -40,7 +44,6 @@ describe Intacct::BaseFactory do
 
   it "proxies build to the target class" do
     attrs = double
-    allow(Intacct::Models::Foo).to receive(:build)
     subject.build(attrs)
     expect(Intacct::Models::Foo).to have_received(:build) do |*args, **_kwargs|
       expect(args).to eq([client, attrs])

--- a/spec/lib/intacct/base_factory_spec.rb
+++ b/spec/lib/intacct/base_factory_spec.rb
@@ -18,14 +18,12 @@ describe Intacct::BaseFactory do
   end
 
   it "proxies get to the target class" do
-    expect(Intacct::Models::Foo).to receive(:get) do |*args, **_kwargs|
-      expect(args).to eq [client, "1"]
-    end
+    expect(Intacct::Models::Foo).to receive(:get).with(client, "1")
     subject.get("1")
   end
 
   it "proxies read_by_query to the target class" do
-    expect(Intacct::Models::Foo).to receive(:read_by_query).with(client, query: "FOO")
+    expect(Intacct::Models::Foo).to receive(:read_by_query).with(client, { query: "FOO" })
     subject.read_by_query(query: "FOO")
   end
 

--- a/spec/lib/intacct/base_factory_spec.rb
+++ b/spec/lib/intacct/base_factory_spec.rb
@@ -20,7 +20,7 @@ describe Intacct::BaseFactory do
   it "proxies get to the target class" do
     allow(Intacct::Models::Foo).to receive(:get)
     subject.get("1")
-    expect(Intacct::Models::Foo).to have_received(:get) do |*args, **kwargs|
+    expect(Intacct::Models::Foo).to have_received(:get) do |*args, **_kwargs|
       expect(args).to eq([client, "1"])
     end
   end
@@ -40,7 +40,10 @@ describe Intacct::BaseFactory do
 
   it "proxies build to the target class" do
     attrs = double
-    expect(Intacct::Models::Foo).to receive(:build).with(client, attrs)
+    allow(Intacct::Models::Foo).to receive(:build)
     subject.build(attrs)
+    expect(Intacct::Models::Foo).to have_received(:build) do |*args, **_kwargs|
+      expect(args).to eq([client, attrs])
+    end
   end
 end

--- a/spec/lib/intacct/base_factory_spec.rb
+++ b/spec/lib/intacct/base_factory_spec.rb
@@ -18,13 +18,20 @@ describe Intacct::BaseFactory do
   end
 
   it "proxies get to the target class" do
-    expect(Intacct::Models::Foo).to receive(:get).with(client, "1")
+    allow(Intacct::Models::Foo).to receive(:get)
     subject.get("1")
+    expect(Intacct::Models::Foo).to have_received(:get) do |*args, **kwargs|
+      expect(args).to eq([client, "1"])
+    end
   end
 
   it "proxies read_by_query to the target class" do
-    expect(Intacct::Models::Foo).to receive(:read_by_query).with(client, { query: "FOO" })
+    allow(Intacct::Models::Foo).to receive(:read_by_query)
     subject.read_by_query(query: "FOO")
+    expect(Intacct::Models::Foo).to have_received(:read_by_query) do |*args, **kwargs|
+      expect(args).to eq([client])
+      expect(kwargs).to eq({ query: "FOO" })
+    end
   end
 
   it "returns the target class" do

--- a/spec/lib/intacct/base_factory_spec.rb
+++ b/spec/lib/intacct/base_factory_spec.rb
@@ -4,11 +4,6 @@ describe Intacct::BaseFactory do
   module Intacct
     module Models
       class Foo
-        def self.get(*args); end
-
-        def self.read_by_query(*args); end
-
-        def self.build(*args); end
       end
     end
   end
@@ -23,7 +18,9 @@ describe Intacct::BaseFactory do
   end
 
   it "proxies get to the target class" do
-    expect(Intacct::Models::Foo).to receive(:get).with(client, "1")
+    expect(Intacct::Models::Foo).to receive(:get) do |*args, **_kwargs|
+      expect(args).to eq [client, "1"]
+    end
     subject.get("1")
   end
 


### PR DESCRIPTION
- Fixed a Ruby 3 keyword argument incompatibility
- Updated some dependencies in order to successfully bundle install
- Updated some RSpec syntax
- Added RSpec to CI 
- Did not add Cucumber to CI as I don't know if we want to support it. But I left it in for posterity in case anyone works in here again.

https://kantata.atlassian.net/browse/IE-515